### PR TITLE
previous PR fixes, updated vulcan metrics from original vulcan, and more

### DIFF
--- a/vulcanai2/datasets/__init__.py
+++ b/vulcanai2/datasets/__init__.py
@@ -1,0 +1,2 @@
+from .fashion import FashionData
+from .tabulardataset import TabularDataset

--- a/vulcanai2/models/basenetwork.py
+++ b/vulcanai2/models/basenetwork.py
@@ -47,16 +47,19 @@ class BaseNetwork(nn.Module):
 
         self._save_path = save_path
 
-        self._input_network = input_network #TODO: change and check type here?
+        self._input_network = input_network
         self._num_classes = num_classes
-        self._activation = activation
-        self._pred_activation = pred_activation
+        
         self._optim_spec = optim_spec
         self._lr_scheduler = lr_scheduler
         self._stopping_rule = stopping_rule
         self._criter_spec = criter_spec
         
-        self._create_network()
+        self._create_network(activation, pred_activation)
+        if self._num_classes:
+            self.metrics = Metrics(self._num_classes)
+        
+        self.optim = None
         self._itr = 0
 
 
@@ -110,15 +113,23 @@ class BaseNetwork(nn.Module):
     def criterion(self):
         return self._criterion
 
-    def get_conv_output_size(self):
+    def get_flattened_size(self, network):
         """
-        Helper function to calculate the size of the flattened 
-        features after the last conv layer
+        Returns the flattened output size of the conv network's last layer
         """
         with torch.no_grad():
             x = torch.ones(1, *self.in_dim)
-            x = self.conv_network(x)
+            x = network(x)
             return x.numel()
+    
+    def get_size(self, network):
+        """
+        Returns the output size of the network's last layer
+        """
+        with torch.no_grad():
+            x = torch.ones(1, self.in_dim)
+            x = network(x)
+            return x.size()[1]
 
     def get_weights(self):
         """
@@ -188,12 +199,10 @@ class BaseNetwork(nn.Module):
         self.criterion = self._get_criterion(self._criter_spec)
 
         self.valid_interv = 2*len(self.train_loader)
-        self.metrics = Metrics(self._num_classes)
         self.epoch = 0
 
 
-    def fit(self, train_loader, val_loader, epochs, retain_graph=False, valid_interv=None,
-                                                            print_iu=False):
+    def fit(self, train_loader, val_loader, epochs, retain_graph=False, valid_interv=None):
         
         self.train_loader = train_loader
         self.val_loader = val_loader
@@ -201,86 +210,101 @@ class BaseNetwork(nn.Module):
         self.retain_graph = retain_graph
         if valid_interv:
             self.valid_interv = valid_interv
-        self.print_iu = print_iu
 
         self._init_trainer()
 
         for epoch in trange(self.epoch, epochs, desc='Epoch: ', ncols=80):
-            self.epoch = epoch
-            self.train_epoch()                    
+            train_loss, train_acc= self.train_epoch()
+            valid_loss, acc, avg_acc, iou, miou, conf_mat = self.validate()
+            tqdm.write("\n Epoch {}:\nTrain Loss: {:.6f} | Test Loss: {:.6f} | Train Acc: {:.2f}% | Test Acc: {:.2f}%".format(epoch, train_loss, valid_loss, train_acc*100, avg_acc*100))            
 
 
     def train_epoch(self):
-
         self.train()  # Set model to training mode
 
-        for batch_idx, (data, targets) in tqdm(
-                                            enumerate(self.train_loader), 
-                                            total=len(self.train_loader),
-                                            desc='Training at epoch=%d' % self.epoch, 
-                                            ncols=80,
-                                            leave=False):
-
-            itr = batch_idx + self.epoch * len(self.train_loader)
-
-            self._itr = itr
-
-            if self._itr > 0 and self._itr % self.valid_interv == 0:
-                self.validate()
+        train_loss = 0
+        pbar = trange(len(self.train_loader.dataset), desc ='Training.. ')
+        for batch_idx, (data, targets) in enumerate(self.train_loader):
 
             data, targets = Variable(data), Variable(targets)
-
-            assert self.training
 
             if torch.cuda.is_available():
                 data, targets = data.cuda(), targets.cuda()
 
             # Forward + Backward + Optimize
-            self.optim.zero_grad()
             predictions = self(data)
             loss = self.criterion(predictions, targets)
-            loss /= len(targets)
-            loss_data = float(loss.item()) 
+            
+            train_loss += loss.item()
+
+            self.optim.zero_grad()
             loss.backward(retain_graph=self.retain_graph)
             self.optim.step()
 
-            correct, acc = self.metrics.get_accuracy(predictions, targets)
-        tqdm.write("\n Epoch {}: Train Loss: {}, Acc: {}%".format(self.epoch, loss_data, correct))
+            if batch_idx % 10 == 0:
+                # Update tqdm bar
+                if ((batch_idx+10)*len(data)) <= len(self.train_loader.dataset):
+                    pbar.update(10 * len(data))
+                else:
+                    pbar.update(len(self.train_loader.dataset) - int(batch_idx*len(data)))
 
+            _, acc = self.metrics.get_accuracy(predictions, targets)
+
+        pbar.close()
+        return (train_loss*len(data)/len(self.train_loader.dataset), acc)
+            
     def validate(self):
-        training = self.training
         self.eval()  # Set model to evaluate mode
-
+        
         val_loss = 0
-        for batch_idx, (data, targets) in tqdm(
-                                            enumerate(self.val_loader), 
-                                            total=len(self.val_loader),
-                                            desc='Validating at epoch=%d' % self.epoch, 
-                                            ncols=80,
-                                            leave=False):
-
-            data, targets = Variable(data), Variable(targets)
+        pbar = trange(len(self.val_loader.dataset), desc ='Validating.. ')
+        for batch_idx, (data, targets) in enumerate(self.val_loader):
+                                            
+            data, targets = Variable(data, requires_grad=False), Variable(targets, requires_grad=False)
 
             if torch.cuda.is_available():
                 data, targets = data.cuda(), targets.cuda()
-
+            
             predictions = self(data)
             loss = self.criterion(predictions, targets)
             loss_data = float(loss.item())
-            val_loss += loss_data / len(targets)
+            val_loss += loss_data / len(self.val_loader.dataset)
 
-            self.metrics.update(predictions.data.max(1)[1].cpu().numpy(), targets.cpu().numpy())
+            self.metrics.update(predictions.data.cpu().numpy(), targets.cpu().numpy())
+            if batch_idx % 10 == 0:
+                # Update tqdm bar
+                if ((batch_idx+10)*len(data)) <= len(self.val_loader.dataset):
+                    pbar.update(10 * len(data))
+                else:
+                    pbar.update(len(self.val_loader.dataset) - int(batch_idx*len(data)))
 
-        score, class_iou = self.metrics.get_scores()
-        tqdm.write("    Valid Loss: {}".format(val_loss))
-        for k, v in score.items():
-            tqdm.write("        {}{}".format(k, v))
-        if self.print_iu is True:
-            for i in range(self._num_classes):
-                tqdm.write("        {}: {}".format(i, class_iou[i]))
-        
-        if training:
-            self.train()
+        accuracy, avg_accuracy, IoU, mIoU, conf_mat = self.metrics.get_scores()
+        self.metrics.reset()
+        pbar.close()
+        return (val_loss, accuracy, avg_accuracy, IoU, mIoU, conf_mat)
+    
+    def run_test(self, test_x, test_y, figure_path=None, plot=False):
+        """
+        Will conduct the test suite to determine model strength.
+        """
+        return self.metrics.run_test(self, test_x, test_y, figure_path, plot)
+
+    def forward_pass(self, input_data, convert_to_class=False):
+        """
+        Allow the implementer to quickly get outputs from the network.
+
+        Args:
+            input_data: Numpy matrix to make the predictions on
+            convert_to_class: If true, output the class
+                             with highest probability
+
+        Returns: Numpy matrix with the output probabilities
+                 with each class unless otherwise specified.
+        """
+        if convert_to_class:
+            return self.cpu().metrics.get_class(self(torch.Tensor(input_data)))
+        else:
+            return self.cpu()(torch.Tensor(input_data))
 
     #TODO: this is copy pasted - edit as appropriate
     def save_model(self, save_path='models'):
@@ -326,237 +350,6 @@ class BaseNetwork(nn.Module):
 
     def save_metadata(self):
         pass
-
-    # def run_test(network, test_x, test_y, figure_path='figures', plot=True):
-    #     """
-    #     Will conduct the test suite to determine model strength.
-    #     Args:
-    #         test_x: data the model has not yet seen to predict
-    #         test_y: corresponding truth vectors
-    #         figure_path: string, folder to place images in.
-    #         plot: bool, determines if graphs should be plotted when ran.
-    #     """
-    #     if network.num_classes is None or network.num_classes == 0:
-    #         raise ValueError('There\'s no classification layer')
-    #
-    #     if test_y.shape[1] > 1:
-    #         test_y = get_class(test_y)  # Y is in one hot representation
-    #
-    #     raw_prediction = network.forward_pass(input_data=test_x,
-    #                                           convert_to_class=False)
-    #     class_prediction = get_class(raw_prediction)
-    #
-    #     confusion_matrix = get_confusion_matrix(
-    #         prediction=class_prediction,
-    #         truth=test_y
-    #     )
-    #
-    #     tp = np.diagonal(confusion_matrix).astype('float32')
-    #     tn = (np.array([np.sum(confusion_matrix)] *
-    #                    confusion_matrix.shape[0]) -
-    #           confusion_matrix.sum(axis=0) -
-    #           confusion_matrix.sum(axis=1) + tp).astype('float32')
-    #     # sum each column and remove diagonal
-    #     fp = (confusion_matrix.sum(axis=0) - tp).astype('float32')
-    #     # sum each row and remove diagonal
-    #     fn = (confusion_matrix.sum(axis=1) - tp).astype('float32')
-    #
-    #     sens = np.nan_to_num(tp / (tp + fn))  # recall
-    #     spec = np.nan_to_num(tn / (tn + fp))
-    #     sens_macro = np.nan_to_num(sum(tp) / (sum(tp) + sum(fn)))
-    #     spec_macro = np.nan_to_num(sum(tn) / (sum(tn) + sum(fp)))
-    #     dice = 2 * tp / (2 * tp + fp + fn)
-    #     ppv = np.nan_to_num(tp / (tp + fp))  # precision
-    #     ppv_macro = np.nan_to_num(sum(tp) / (sum(tp) + sum(fp)))
-    #     npv = np.nan_to_num(tn / (tn + fn))
-    #     npv_macro = np.nan_to_num(sum(tn) / (sum(tn) + sum(fn)))
-    #     accuracy = np.sum(tp) / np.sum(confusion_matrix)
-    #     f1 = np.nan_to_num(2 * (ppv * sens) / (ppv + sens))
-    #     f1_macro = np.average(np.nan_to_num(2 * sens * ppv / (sens + ppv)))
-    #
-    #     print('{} test\'s results'.format(network.name))
-    #
-    #     print('TP:'),
-    #     print(tp)
-    #     print('FP:'),
-    #     print(fp)
-    #     print('TN:'),
-    #     print(tn)
-    #     print('FN:'),
-    #     print(fn)
-    #
-    #     print('\nAccuracy: {}'.format(accuracy))
-    #
-    #     print('Sensitivity:'),
-    #     print(round_list(sens, decimals=3))
-    #     print('\tMacro Sensitivity: {:.4f}'.format(sens_macro))
-    #
-    #     print('Specificity:'),
-    #     print(round_list(spec, decimals=3))
-    #     print('\tMacro Specificity: {:.4f}'.format(spec_macro))
-    #
-    #     print('DICE:'),
-    #     print(round_list(dice, decimals=3))
-    #     print('\tAvg. DICE: {:.4f}'.format(np.average(dice)))
-    #
-    #     print('Positive Predictive Value:'),
-    #     print(round_list(ppv, decimals=3))
-    #     print('\tMacro Positive Predictive Value: {:.4f}'.format
-    #           (ppv_macro))
-    #
-    #     print('Negative Predictive Value:'),
-    #     print(round_list(npv, decimals=3))
-    #     print('\tMacro Negative Predictive Value: {:.4f}'.format
-    #           (npv_macro))
-    #
-    #     print('f1-score:'),
-    #     print(round_list(f1, decimals=3))
-    #     print('\tMacro f1-score: {:.4f}'.format(f1_macro))
-    #     print('')
-    #
-    #     if not os.path.exists(figure_path):
-    #         print('Creating figures folder')
-    #         os.makedirs(figure_path)
-    #
-    #     if not os.path.exists('{}/{}{}'.format(figure_path, network.timestamp,
-    #                                            network.name)):
-    #         print('Creating {}/{}{} folder'.format(figure_path,
-    #                                                network.timestamp,
-    #                                                network.name))
-    #         os.makedirs('{}/{}{}'.format(
-    #             figure_path,
-    #             network.timestamp,
-    #             network.name)
-    #         )
-    #     print('Saving ROC figures to folder: {}/{}{}'.format(
-    #         figure_path,
-    #         network.timestamp,
-    #         network.name)
-    #     )
-    #
-    #     plt.figure()
-    #     plt.title("Confusion matrix for {}".format(network.name))
-    #     plt.xticks(range(confusion_matrix.shape[0]))
-    #     plt.yticks(range(confusion_matrix.shape[0]))
-    #     plt.ylabel('True label')
-    #     plt.xlabel('Predicted label')
-    #     plt.imshow(confusion_matrix, origin='lower', cmap='hot',
-    #                interpolation='nearest')
-    #     plt.colorbar()
-    #
-    #     plt.savefig('{}/{}{}/confusion_matrix.png'.format(
-    #         figure_path,
-    #         network.timestamp,
-    #         network.name))
-    #     if not plot:
-    #         plt.close()
-    #
-    #     fig = plt.figure()
-    #     all_class_auc = []
-    #     for i in range(network.num_classes):
-    #         if network.num_classes == 1:
-    #             fpr, tpr, thresholds = metrics.roc_curve(test_y,
-    #                                                      raw_prediction,
-    #                                                      pos_label=1)
-    #         else:
-    #             fpr, tpr, thresholds = metrics.roc_curve(test_y,
-    #                                                      raw_prediction[:, i],
-    #                                                      pos_label=i)
-    #
-    #         auc = metrics.auc(fpr, tpr)
-    #         all_class_auc += [auc]
-    #         # print ('AUC: {:.4f}'.format(auc))
-    #         # print ('\tGenerating ROC {}/{}{}/{}.png ...'.format(figure_path,
-    #         #                                                     network.timestamp,
-    #         #                                                     network.name, i))
-    #         plt.clf()
-    #         plt.plot(fpr, tpr, label=("AUC: {:.4f}".format(auc)))
-    #         plt.title("ROC Curve for {}_{}".format(network.name, i))
-    #         plt.xlabel('1 - Specificity')
-    #         plt.ylabel('Sensitivity')
-    #         plt.legend(loc='lower right')
-    #         plt.ylim(0.0, 1.0)
-    #         plt.xlim(0.0, 1.0)
-    #
-    #         plt.savefig('{}/{}{}/{}.png'.format(figure_path,
-    #                                             network.timestamp,
-    #                                             network.name, i))
-    #         if plot:
-    #             plt.show(False)
-    #
-    #     if not plot:
-    #         plt.close(fig.number)
-    #     print('Average AUC: : {:.4f}'.format(np.average(all_class_auc)))
-    #     return {
-    #         'accuracy': accuracy,
-    #         'macro_sensitivity': sens_macro,
-    #         'macro_specificity': spec_macro,
-    #         'avg_dice': np.average(dice),
-    #         'macro_ppv': ppv_macro,
-    #         'macro_npv': npv_macro,
-    #         'macro_f1': f1_macro,
-    #         'macro_auc': np.average(all_class_auc)
-    #     }
-    #
-    # def k_fold_validation(network, train_x, train_y, k=5, epochs=10,
-    #                       batch_ratio=1.0, plot=False):
-    #     """
-    #     Conduct k fold cross validation on a network.
-    #     Args:
-    #         network: Network object you want to cross validate
-    #         train_x: ndarray of shape (batch, features), train samples
-    #         train_y: ndarray of shape(batch, classes), train labels
-    #         k: int, how many folds to run
-    #         batch_ratio: float, 0-1 for % of total to allocate for a batch
-    #         epochs: int, number of epochs to train each fold
-    #     Returns final metric dictionary
-    #     """
-    #     try:
-    #         network.save_name
-    #     except:
-    #         network.save_model()
-    #     chunk_size = int((train_x.shape[0]) / k)
-    #     results = []
-    #     timestamp = get_timestamp()
-    #     for i in range(k):
-    #         val_x = train_x[i * chunk_size:(i + 1) * chunk_size]
-    #         val_y = train_y[i * chunk_size:(i + 1) * chunk_size]
-    #         tra_x = np.concatenate(
-    #             (train_x[:i * chunk_size], train_x[(i + 1) * chunk_size:]),
-    #             axis=0
-    #         )
-    #         tra_y = np.concatenate(
-    #             (train_y[:i * chunk_size], train_y[(i + 1) * chunk_size:]),
-    #             axis=0
-    #         )
-    #         net = deepcopy(network)
-    #         net.train(
-    #             epochs=epochs,
-    #             train_x=tra_x,
-    #             train_y=tra_y,
-    #             val_x=val_x,
-    #             val_y=val_y,
-    #             batch_ratio=batch_ratio,
-    #             plot=plot
-    #         )
-    #         results += [Counter(run_test(
-    #             net,
-    #             val_x,
-    #             val_y,
-    #             figure_path='figures/kfold_{}{}'.format(timestamp, network.name),
-    #             plot=plot))]
-    #         del net
-    #     aggregate_results = reduce(lambda x, y: x + y, results)
-    #
-    #     print('\nFinal Cross validated results')
-    #     print('-----------------------------')
-    #     for metric_key in aggregate_results.keys():
-    #         aggregate_results[metric_key] /= float(k)
-    #         print('{}: {:.4f}'.format(metric_key, aggregate_results[metric_key]))
-    #
-    #     return aggregate_results
-    #
-
 
     def _transfer_optimizer_state_to_right_device(self):
         # Since the optimizer state is loaded on CPU, it will crashed when the

--- a/vulcanai2/models/dnn.py
+++ b/vulcanai2/models/dnn.py
@@ -5,6 +5,7 @@ import torch.nn.modules.activation as activations
 import torch.optim as optim
 
 from .basenetwork import BaseNetwork
+from .cnn import ConvNet
 from .layers import DenseUnit, ConvUnit
 
 import numpy as np
@@ -28,25 +29,51 @@ class DenseNet(BaseNetwork, nn.Module):
         super(DenseNet, self).__init__(name, dimensions, config, save_path, input_network, num_classes, 
                 activation, pred_activation, optim_spec, lr_scheduler, stopping_rule, criter_spec)
 
-    def _create_network(self):
+    def _create_network(self, activation, pred_activation):
+        self._activation = activation
+        self._pred_activation = pred_activation
         self.in_dim = self._dimensions
-        self.out_dim = self._num_classes
 
-        dims = [self.in_dim] + self._config["units"]
-        self.dense_network = self.build_dense_network(dims)
-        self.dense_network.add_module('Lastlayer', DenseUnit(dims[-1], self.out_dim))  # TODO: Add ClassificationUnit?
+        if self._input_network and isinstance(self._input_network, ConvNet):
+            if self._input_network.conv_flat_dim != self.in_dim:
+                self.in_dim = self.get_flattened_size(self._input_network)
+            else:
+                pass
 
-        self.init_layers(self.modules())
-        if torch.cuda.is_available():
-            for module in self.modules():
-                module.cuda()
+        if self._input_network and isinstance(self._input_network, DenseNet):
+            if self._input_network.dims[-1] != self.in_dim:
+                self.in_dim = self.dims[-1]
+            else:
+                pass
+
+        self.dims = [self.in_dim] + self._config["dense_units"]
+        self.dense_network = self.build_dense_network(self.dims)
         
+        if self._num_classes:
+            self.out_dim = self._num_classes
+            self._create_classification_layer(self.dims[-1])
+
+            if torch.cuda.is_available():
+                for module in self.modules():
+                    module.cuda()
+
+    def _create_classification_layer(self, dim):
+        self.network_tail = DenseUnit(dim, self.out_dim)
+
     def forward(self, x):
         '''The feedforward step'''
-        return self.dense_network(x)
+        if self._input_network: 
+            x = self._input_network(x)
 
-    def __str__(self):
-        return super(DenseNet, self).__str__() + f'\noptim: {self.optim}'
+        if isinstance(self._input_network, ConvNet):
+            x = x.view(-1, self._input_network.conv_flat_dim)
+
+        x = self.dense_network(x)
+        if self._num_classes:
+            output = self.network_tail(x)
+            return output
+        else:
+            return x
 
     def build_dense_network(self, dims):
         dim_pairs = list(zip(dims[:-1], dims[1:]))
@@ -58,3 +85,10 @@ class DenseNet(BaseNetwork, nn.Module):
                                           activation=self._activation))
         dense_network = nn.Sequential(*dense_layers)
         return dense_network
+
+    def __str__(self):
+        if self.optim:
+            return super(DenseNet, self).__str__() + f'\noptim: {self.optim}'
+        else:
+            return super(DenseNet, self).__str__()
+        

--- a/vulcanai2/models/metrics.py
+++ b/vulcanai2/models/metrics.py
@@ -1,57 +1,107 @@
 import numpy as np
+
 import torch
 import torch.nn.functional as F
 from torch.autograd import Variable
-from sklearn import metrics as scipy_metrics
+
+import math
+import numpy as np
+from sklearn import metrics as skl_metrics
+from sklearn.metrics import confusion_matrix
+from sklearn.preprocessing import LabelBinarizer
+from sklearn.manifold import TSNE
+from sklearn.decomposition import PCA
+
+from copy import deepcopy
+
+from collections import Counter
+
 import logging
 logger = logging.getLogger(__name__)
 
 class Metrics(object):
 
-    def __init__(self, num_class):
+    def __init__(self, num_class, use_unlabeled=False):
+        self.mat = np.zeros((num_class, num_class), dtype=np.float)
+        self.valids = np.zeros((num_class), dtype=np.float)
+        self.IoU = np.zeros((num_class), dtype=np.float)
+        self.mIoU = 0
+
         self.num_class = num_class
-        self.confusion_matrix = np.zeros((num_class, num_class))
-
-    def _fast_hist(self, prediction, target, num_class):
-        mask = (target >= 0) & (target < num_class)
-        hist = np.bincount(
-                            num_class * target[mask].astype(int) + prediction[mask],
-                            minlength=num_class ** 2,
-                            ).reshape(num_class, num_class)
-        return hist
-    def update(self, predictions, targets):
-        for prediction, target in zip(predictions, targets):
-            self.confusion_matrix += self._fast_hist(
-                prediction.flatten(), target.flatten(), self.num_class)
-
-    def get_scores(self):
-        """Returns accuracy score evaluation result.
-            - overall accuracy
-            - mean accuracy
-            - mean IU
-        """
-        hist = self.confusion_matrix
-        acc = np.diag(hist).sum() / hist.sum()
-        acc_cls = np.diag(hist) / hist.sum(axis=1)
-        acc_cls = np.nanmean(acc_cls)
-        iu = np.diag(hist) / (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
-        mean_iu = np.nanmean(iu)
-        cls_iu = dict(zip(range(self.num_class), iu))
-
-        return (
-            {
-                "Overall Acc: \t": acc,
-                "Mean Acc : \t": acc_cls,
-                "Mean IoU : \t": mean_iu,
-            },
-            cls_iu,
-            )  
+        self.list_classes = list(range(num_class))
+        self.use_unlabeled = use_unlabeled
+        self.mat_start_idx = 1 if not self.use_unlabeled else 0
 
     def reset(self):
-        self.confusion_matrix = np.zeros((self.n_classes, self.n_classes))
+        self.mat = np.zeros((self.num_class, self.num_class), dtype=float)
+        self.valids = np.zeros((self.num_class), dtype=float)
+        self.IoU = np.zeros((self.num_class), dtype=float)
+        self.mIoU = 0
+    
+    def update(self, predictions, targets):
+        if not(isinstance(predictions, np.ndarray)) or not(isinstance(targets, np.ndarray)):
+            print("Expected ndarray")
 
-    def average(self):
-        pass
+        elif len(targets.shape) == 3:        # batched spatial target
+            if len(predictions.shape) == 4:  # prediction is 1 hot encoded
+                temp_predictions = np.argmax(predictions, axis=1).flatten()
+            elif len(predictions.shape) == 3:
+                temp_predictions = predictions.flatten()
+            else:
+                print("Predictions and Targets does not match")
+            temp_targets = targets.flatten()
+
+        elif len(targets.shape) == 2:        # spatial target
+            if len(predictions.shape) == 3:  # prediction is 1 hot encoded
+                temp_predictions = np.argmax(predictions, axis=1).flatten()
+            elif len(predictions.shape) == 2:
+                temp_predictions = predictions.flatten()
+            else:
+                print("Predictions and Targets does not match")
+            temp_targets = targets.flatten()
+
+        elif len(targets.shape) == 1:
+            if len(predictions.shape) == 2:  # prediction is 1 hot encoded
+                temp_predictions = np.argmax(predictions, axis=1).flatten()
+            elif len(predictions.shape) == 1:
+                temp_predictions = predictions
+            else:
+                print("Predictions and Targets does not match")
+            temp_targets = targets
+        else:
+            print("Data with this dimension cannot be handled")
+
+        self.mat += confusion_matrix(temp_targets, temp_predictions, labels=self.list_classes)
+
+    def get_scores(self):
+        tp = 0
+        fp = 0
+        tn = 0
+        fn = 0
+        total = 0   # Total true positives
+        N = 0       # Total samples
+        for i in range(self.mat_start_idx, self.num_class):
+            N += sum(self.mat[:, i])
+            tp = self.mat[i][i]
+            fp = sum(self.mat[self.mat_start_idx:, i]) - tp
+            fn = sum(self.mat[i,self.mat_start_idx:]) - tp
+
+            if (tp+fp) == 0:
+                self.valids[i] = 0
+            else:
+                self.valids[i] = tp/(tp + fp)
+
+            if (tp+fp+fn) == 0:
+                self.IoU[i] = 0
+            else:
+                self.IoU[i] = tp/(tp + fp + fn)
+
+            total += tp
+
+        self.mIoU = sum(self.IoU[self.mat_start_idx:])/(self.num_class - self.mat_start_idx)
+        self.acc = total/(sum(sum(self.mat[self.mat_start_idx:, self.mat_start_idx:])))
+
+        return self.valids, self.acc, self.IoU, self.mIoU, self.mat           
 
     def get_accuracy(self, predictions, targets):
         max_index = predictions.max(dim=1)[1]
@@ -59,8 +109,263 @@ class Metrics(object):
         accuracy = int(correct.data) / len(targets)
         return correct, accuracy
 
-    def get_precision(predictions, targets):
-        return scipy_metrics.precision_score(targets.flatten(), predictions.flatten())
+    def get_precision(self, predictions, targets):
+        return skl_metrics.precision_score(targets.flatten(), predictions.flatten())
 
-    def get_roc_score(predictions, targets):
-        return scipy_metrics.roc_auc_score(targets.flatten(), predictions.flatten())
+    def get_roc_score(self, predictions, targets):
+        return skl_metrics.roc_auc_score(targets.flatten(), predictions.flatten())
+
+
+    def get_notable_indices(self, matrix, top_k=5):
+        """
+        Return dict of top k and bottom k features useful from matrix.
+
+        Args:
+            matrix: 1d numpy array
+            top_k: defaults to top and bottom 5 indices
+        """
+        important_features = matrix.argsort()[-top_k:][::-1]
+        unimportant_features = matrix.argsort()[:-1][:top_k]
+        return {'important_indices': important_features,
+                'unimportant_indices': unimportant_features}
+
+    def round_list(self, raw_list, decimals=4):
+        """
+        Return the same list with each item rounded off.
+
+        Args:
+            raw_list: float list
+            decimals: how many decimal points to round to
+
+        Returns: the rounded list
+        """
+        return [round(item, decimals) for item in raw_list]
+
+    def get_confusion_matrix(self, predictions, targets):
+        """
+        Calculate the confusion matrix for classification network predictions.
+
+        Args:
+            predictions: the class matrix predicted by the network.
+                    Does not take one hot vectors.
+            targets: the class matrix of the ground truth
+                    Does not take one hot vectors.
+
+        Returns: the confusion matrix
+        """
+        print(type(predictions))
+        if len(predictions.shape) == 2:
+            predictions = predictions[:, 0]
+        if len(targets.shape) == 2:
+            targets = targets[:, 0]
+        return confusion_matrix(y_true=targets,
+                                y_pred=predictions)
+
+    def get_one_hot(self, in_matrix):
+        """
+        Reformat truth matrix to same size as the output of the dense network.
+
+        Args:
+            in_matrix: the categorized 1D matrix
+
+        Returns: a one-hot matrix representing the categorized matrix
+        """
+        if in_matrix.dtype.name == 'category':
+            custum_array = in_matrix.cat.codes
+
+        elif isinstance(in_matrix, np.ndarray):
+            custum_array = in_matrix
+
+        else:
+            raise ValueError("Input matrix cannot be converted.")
+
+        lb = LabelBinarizer()
+        return np.array(lb.fit_transform(custum_array), dtype='float32')
+
+    def get_class(self, in_matrix):
+        """
+        Reformat truth matrix to be the classes in a 1D array.
+
+        Args:
+            in_matrix: one-hot matrix
+
+        Returns: Class array
+        """
+        in_matrix= in_matrix.detach()
+        if in_matrix.shape[1] > 1:
+            return np.expand_dims(np.argmax(in_matrix, axis=1), axis=1)
+        elif in_matrix.shape[1] == 1:
+            return np.around(in_matrix)
+
+    def run_test(self, model, test_x, test_y, figure_path=None, plot=False):
+        """
+        Will conduct the test suite to determine model strength.
+
+        Args:
+            test_x: data the model has not yet seen to predict
+            test_y: corresponding truth vectors
+            figure_path: string, folder to place images in.
+            plot: bool, determines if graphs should be plotted when ran.
+        """
+        if model._num_classes is None or model._num_classes == 0:
+            raise ValueError('There\'s no classification layer')
+
+        if test_y.shape[1] > 1:
+            test_y = self.get_class(test_y)  # Y is in one hot representation
+
+        raw_prediction = model.forward_pass(input_data=test_x,
+                                            convert_to_class=False)
+        class_prediction = self.get_class(raw_prediction)
+
+        confusion_matrix = self.get_confusion_matrix(
+            predictions=class_prediction,
+            targets=test_y
+        )
+
+        tp = np.diagonal(confusion_matrix).astype('float32')
+        tn = (np.array([np.sum(confusion_matrix)] *
+                    confusion_matrix.shape[0]) -
+            confusion_matrix.sum(axis=0) -
+            confusion_matrix.sum(axis=1) + tp).astype('float32')
+        # sum each column and remove diagonal
+        fp = (confusion_matrix.sum(axis=0) - tp).astype('float32')
+        # sum each row and remove diagonal
+        fn = (confusion_matrix.sum(axis=1) - tp).astype('float32')
+
+        sens = np.nan_to_num(tp / (tp + fn))  # recall
+        spec = np.nan_to_num(tn / (tn + fp))
+        sens_macro = np.nan_to_num(sum(tp) / (sum(tp) + sum(fn)))
+        spec_macro = np.nan_to_num(sum(tn) / (sum(tn) + sum(fp)))
+        dice = 2 * tp / (2 * tp + fp + fn)
+        ppv = np.nan_to_num(tp / (tp + fp))  # precision
+        ppv_macro = np.nan_to_num(sum(tp) / (sum(tp) + sum(fp)))
+        npv = np.nan_to_num(tn / (tn + fn))
+        npv_macro = np.nan_to_num(sum(tn) / (sum(tn) + sum(fn)))
+        accuracy = np.sum(tp) / np.sum(confusion_matrix)
+        f1 = np.nan_to_num(2 * (ppv * sens) / (ppv + sens))
+        f1_macro = np.average(np.nan_to_num(2 * sens * ppv / (sens + ppv)))
+
+        print ('{} test\'s results'.format(model.name))
+
+        print ('TP:'),
+        print (tp)
+        print ('FP:'),
+        print (fp)
+        print ('TN:'),
+        print (tn)
+        print ('FN:'),
+        print (fn)
+
+        print ('\nAccuracy: {}'.format(accuracy))
+
+        print ('Sensitivity:'),
+        print(self.round_list(sens, decimals=3))
+        print ('\tMacro Sensitivity: {:.4f}'.format(sens_macro))
+
+        print ('Specificity:'),
+        print(self.round_list(spec, decimals=3))
+        print ('\tMacro Specificity: {:.4f}'.format(spec_macro))
+
+        print ('DICE:'),
+        print(self.round_list(dice, decimals=3))
+        print ('\tAvg. DICE: {:.4f}'.format(np.average(dice)))
+
+        print ('Positive Predictive Value:'),
+        print(self.round_list(ppv, decimals=3))
+        print ('\tMacro Positive Predictive Value: {:.4f}'.format
+            (ppv_macro))
+
+        print ('Negative Predictive Value:'),
+        print(self.round_list(npv, decimals=3))
+        print ('\tMacro Negative Predictive Value: {:.4f}'.format
+            (npv_macro))
+
+        print ('F1-score:'),
+        print(self.round_list(f1, decimals=3))
+        print ('\tMacro f1-score: {:.4f}'.format(f1_macro))
+        print('')
+
+        all_class_auc = []
+        for i in range(model._num_classes):
+            if model._num_classes == 1:      
+                fpr, tpr, thresholds = skl_metrics.roc_curve(test_y,
+                                                        raw_prediction.detach(),
+                                                        pos_label=1)
+            else:
+                fpr, tpr, thresholds = skl_metrics.roc_curve(test_y,
+                                                        raw_prediction[:, i].detach(),
+                                                        pos_label=i)
+
+            auc = skl_metrics.auc(fpr, tpr)
+            all_class_auc += [auc]
+
+        return {
+            'accuracy': accuracy,
+            'macro_sensitivity': sens_macro,
+            'macro_specificity': spec_macro,
+            'avg_dice': np.average(dice),
+            'macro_ppv': ppv_macro,
+            'macro_npv': npv_macro,
+            'macro_f1': f1_macro,
+            'macro_auc': np.average(all_class_auc)
+        }
+
+    def k_fold_validation(self, model, train_x, train_y, k=5, epochs=10,
+                        batch_ratio=1.0, plot=False):
+        """
+        Conduct k fold cross validation on a network.
+
+        Args:
+            model: BaseNetwork object you want to cross validate
+            train_x: ndarray of shape (batch, features), train samples
+            train_y: ndarray of shape(batch, classes), train labels
+            k: int, how many folds to run
+            batch_ratio: float, 0-1 for % of total to allocate for a batch
+            epochs: int, number of epochs to train each fold
+
+        Returns final metric dictionary
+        """
+        try:
+            model.save_name
+        except:
+            model.save_model()
+        chunk_size = int((train_x.shape[0]) / k)
+        results = []
+        timestamp = get_timestamp()
+        for i in range(k):
+            val_x = train_x[i * chunk_size:(i + 1) * chunk_size]
+            val_y = train_y[i * chunk_size:(i + 1) * chunk_size]
+            tra_x = np.concatenate(
+                (train_x[:i * chunk_size], train_x[(i + 1) * chunk_size:]),
+                axis=0
+            )
+            tra_y = np.concatenate(
+                (train_y[:i * chunk_size], train_y[(i + 1) * chunk_size:]),
+                axis=0
+            )
+            net = deepcopy(model)
+            net.train(
+                epochs=epochs,
+                train_x=tra_x,
+                train_y=tra_y,
+                val_x=val_x,
+                val_y=val_y,
+                batch_ratio=batch_ratio,
+                plot=plot
+            )
+            results += [Counter(run_test(
+                net,
+                val_x,
+                val_y,
+                figure_path='figures/kfold_{}{}'.format(timestamp, model.name),
+                plot=plot))]
+            del net
+        aggregate_results = reduce(lambda x, y: x + y, results)
+
+        print ('\nFinal Cross validated results')
+        print ('-----------------------------')
+        for metric_key in aggregate_results.keys():
+            aggregate_results[metric_key] /= float(k)
+            print ('{}: {:.4f}'.format(metric_key, aggregate_results[metric_key]))
+
+        return aggregate_results


### PR DESCRIPTION
https://github.com/Aifred-Health/Vulcan2/pull/1 fixes:
- [x] Break down `config['units']` to two: one for `_conv_` and the other for `_dense_`
- [x]  add more detail within the units to specify filter count, filter size, stride, dilation factor, etc
- [x] Generalize `get output size`
- [x] Move back `build_conv_network` and `build_dense_network` to respective network classes
- [x] Move the notebooks to `examples`
- [x] `build_dense_network` must be instantiated in ConvNet only when needed

https://github.com/Aifred-Health/Vulcan2/pull/3 fixes:
- [x] We are missing a few metrics here like sensitivity, specificity, npc, ppv, etc that can be found in the original Vulcan
- [x] use sklearn to generate the confusion matrix (renaming the sklearn import)
- [x] sklearn roc and abc calculation work better than scipy (renaming the sklearn import)
