### PR TITLE
Fix circular imports

### DIFF
--- a/examples/fashion_conv_dense_test.py
+++ b/examples/fashion_conv_dense_test.py
@@ -1,8 +1,9 @@
 import sys
 sys.path.append('../')
 from vulcanai2 import models, datasets, plotters
-from vulcanai2.models.cnn import ConvNet
-from vulcanai2.models.dnn import DenseNet
+from vulcanai2.models import ConvNet, DenseNet, SnapshotNet
+# from vulcanai2.models.cnn import ConvNet
+# from vulcanai2.models.dnn import DenseNet
 from vulcanai2.plotters.visualization import (compute_saliency_map, 
                                               display_saliency_overlay,
                                               display_receptive_fields,
@@ -141,8 +142,6 @@ model1 = DenseNet(
 # y = train_loader.dataset.train_labels[:5]
 # sal_map = compute_saliency_map(model1, x, y)
 # display_saliency_overlay(train_loader.dataset.train_data[0], sal_map[0])
-
-from vulcanai2.models.ensemble import SnapshotNet
 
 se = SnapshotNet("snap", model1, 3)
 

--- a/vulcanai2/datasets/__init__.py
+++ b/vulcanai2/datasets/__init__.py
@@ -2,6 +2,7 @@
 """ Imports dataset classes so they can be used directly"""
 from .fashion import FashionData
 from .tabulardataset import TabularDataset
+
 __all__ = [
     'fashion',
     'tabulardataset',

--- a/vulcanai2/datasets/__init__.py
+++ b/vulcanai2/datasets/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """ Imports dataset classes so they can be used directly"""
+from .fashion import FashionData
+from .tabulardataset import TabularDataset
 __all__ = [
     'fashion',
     'tabulardataset',
-    'utils'
+    'utils',
+    'FashionData',
+    'TabularDataset'
 ]
-from .fashion import FashionData
-from .tabulardataset import TabularDataset

--- a/vulcanai2/models/__init__.py
+++ b/vulcanai2/models/__init__.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 """ Imports network classes so they can be used directly"""
+from .basenetwork import BaseNetwork
+from .cnn import ConvNet
+from .dnn import DenseNet
+from .ensemble import SnapshotNet
+
 __all__ = [
     'basenetwork',
     'cnn',
@@ -7,11 +12,9 @@ __all__ = [
     'layers',
     'ensemble',
     'metrics',
-    'utils'
+    'utils',
+    'BaseNetwork',
+    'ConvNet',
+    'DenseNet',
+    'SnapshotNet'
 ]
-
-# Commenting this leads to circular imports when
-# running test on plotters
-# from .cnn import ConvNet
-# from .dnn import DenseNet
-# from .ensemble import SnapshotNet

--- a/vulcanai2/models/utils.py
+++ b/vulcanai2/models/utils.py
@@ -4,31 +4,6 @@ from sklearn.metrics import confusion_matrix
 from sklearn.preprocessing import LabelBinarizer
 
 
-def get_notable_indices(feature_importances, top_k=5):
-    """
-    Return dict of top k and bottom k features useful from matrix.
-
-    Parameters
-    ----------
-    feature_importance : numpy.ndarray
-        1D numpy array to extract the top of bottom indices.
-    top_k : int
-        How many features from top and bottom to extract.
-        Defaults to 5.
-
-    Returns
-    -------
-    notable_indices : dict
-        Indices of the top most important features.
-        Indices of the bottom mos unimportant features.
-
-    """
-    important_features = feature_importances.argsort()[-top_k:][::-1]
-    unimportant_features = feature_importances.argsort()[:-1][:top_k]
-    return {'important_indices': important_features,
-            'unimportant_indices': unimportant_features}
-
-
 def round_list(raw_list, decimals=4):
     """
     Return the same list with each item rounded off.

--- a/vulcanai2/plotters/__init__.py
+++ b/vulcanai2/plotters/__init__.py
@@ -1,5 +1,22 @@
 # -*- coding: utf-8 -*-
+from .visualization import (
+    compute_saliency_map,
+    display_saliency_overlay,
+    display_pca,
+    display_tsne,
+    display_confusion_matrix,
+    display_record,
+    display_receptive_fields
+)
+
 __all__ = [
     'utils',
-    'visualization'
+    'visualization',
+    'compute_saliency_map',
+    'display_saliency_overlay',
+    'display_pca',
+    'display_tsne',
+    'display_confusion_matrix',
+    'display_record',
+    'display_receptive_fields'
 ]

--- a/vulcanai2/plotters/utils.py
+++ b/vulcanai2/plotters/utils.py
@@ -4,6 +4,31 @@ from torch.nn import ReLU, SELU
 # from ..models.basenetwork import BaseNetwork
 
 
+def get_notable_indices(feature_importances, top_k=5):
+    """
+    Return dict of top k and bottom k features useful from matrix.
+
+    Parameters
+    ----------
+    feature_importance : numpy.ndarray
+        1D numpy array to extract the top of bottom indices.
+    top_k : int
+        How many features from top and bottom to extract.
+        Defaults to 5.
+
+    Returns
+    -------
+    notable_indices : dict
+        Indices of the top most important features.
+        Indices of the bottom mos unimportant features.
+
+    """
+    important_features = feature_importances.argsort()[-top_k:][::-1]
+    unimportant_features = feature_importances.argsort()[:-1][:top_k]
+    return {'important_indices': important_features,
+            'unimportant_indices': unimportant_features}
+
+
 class GuidedBackprop():
     """
     Generate gradients with guided back propagation w.r.t given input.

--- a/vulcanai2/plotters/utils.py
+++ b/vulcanai2/plotters/utils.py
@@ -63,10 +63,10 @@ class GuidedBackprop():
     def _hook_top_layers(self):
         def hook_function(module, grad_in, grad_out):
             # TODO: Revisit dim disorder and check isinstance for classes.
-            if module.__class__.__name__ == 'Linear':
+            if isinstance(module, torch.nn.Linear):
                 # grad_in shape is (bias, input, weights)
                 self.gradients = grad_in[1]
-            elif module.__class__.__bases__[0].__name__ == '_ConvNd':
+            elif isinstance(module, torch.nn.modules.conv._ConvNd):
                 # grad_in shape is (input, weights, bias)
                 self.gradients = grad_in[0]
         # Register hook to the first layer

--- a/vulcanai2/plotters/visualization.py
+++ b/vulcanai2/plotters/visualization.py
@@ -7,8 +7,7 @@ from math import sqrt, ceil, floor
 
 import pickle
 
-from .utils import GuidedBackprop
-from ..models.utils import get_notable_indices
+from .utils import GuidedBackprop, get_notable_indices
 
 from sklearn.manifold import TSNE
 from sklearn.decomposition import PCA

--- a/vulcanai2/tests/models/test_basenetwork.py
+++ b/vulcanai2/tests/models/test_basenetwork.py
@@ -1,10 +1,14 @@
+"""Test BaseNetwork functionality."""
 import pytest
+from vulcanai2.models.basenetwork import BaseNetwork
 
 
 class TestBaseNetwork:
+    """Define BaseNetwork test class."""
+
     @pytest.fixture
     def basenet(self):
-        from vulcanai2.models.basenetwork import BaseNetwork
+        """Create a test BaseNetwork."""
         return BaseNetwork(
             name='Test_BaseNet',
             dimensions=(None, 10),
@@ -12,9 +16,11 @@ class TestBaseNetwork:
         )
 
     def test_name(self, basenet):
+        """Test changing names."""
         basenet.name = 'New_Name'
-        assert basenet.name == 'New_Name'
-    
+        assert basenet.name is 'New_Name'
+
     def test_learning_rate(self, basenet):
+        """Test learning rate change."""
         basenet.learning_rate = 0.1
-        assert basenet.learning_rate == 0.1
+        assert basenet.learning_rate is 0.1

--- a/vulcanai2/tests/models/test_cnn.py
+++ b/vulcanai2/tests/models/test_cnn.py
@@ -1,52 +1,58 @@
+"""Test all ConvNet capabilities."""
 import pytest
 import numpy as np
 import torch
 from vulcanai2.models.cnn import ConvNet
 from torch.utils.data import TensorDataset, DataLoader
 
+
 class TestConvNet:
+    """Define ConvNet test class."""
+
     @pytest.fixture
-    def cnn_noclass(self): 
+    def cnn_noclass(self):
+        """Create ConvNet with no prediction layer."""
         return ConvNet(
             name='Test_ConvNet_noclass',
             dimensions=(1, 28, 28),
             config={
                 'conv_units': [
                     {
-                        "in_channels":1,
-                        "out_channels":16,
-                        "kernel_size":(5, 5),
-                        "stride":2
+                        "in_channels": 1,
+                        "out_channels": 16,
+                        "kernel_size": (5, 5),
+                        "stride": 2
                     },
                     {
-                        "in_channels":16,
-                        "out_channels":1,
-                        "kernel_size":(5, 5),
-                        "stride":1,
-                        "padding":2
+                        "in_channels": 16,
+                        "out_channels": 1,
+                        "kernel_size": (5, 5),
+                        "stride": 1,
+                        "padding": 2
                     }]
             }
         )
 
     @pytest.fixture
     def cnn_class(self):
+        """Create ConvNet with prediction layer."""
         return ConvNet(
             name='Test_ConvNet_class',
             dimensions=(1, 28, 28),
             config={
                 'conv_units': [
                     {
-                        "in_channels":1,
-                        "out_channels":16,
-                        "kernel_size":(5, 5),
-                        "stride":2
+                        "in_channels": 1,
+                        "out_channels": 16,
+                        "kernel_size": (5, 5),
+                        "stride": 2
                     },
                     {
-                        "in_channels":16,
-                        "out_channels":1,
-                        "kernel_size":(5, 5),
-                        "stride":1,
-                        "padding":2
+                        "in_channels": 16,
+                        "out_channels": 1,
+                        "kernel_size": (5, 5),
+                        "stride": 1,
+                        "padding": 2
                     }]
             },
             num_classes=3
@@ -60,7 +66,7 @@ class TestConvNet:
             data_loader=test_dataloader,
             convert_to_class=False)
         assert np.any(~np.isnan(output))
-    
+
     def test_forward_class_not_nan(self, cnn_class):
         """Confirm out is non nan."""
         test_input = torch.ones([1, *cnn_class.in_dim])
@@ -73,3 +79,32 @@ class TestConvNet:
         assert np.any(~np.isnan(class_output))
         assert np.any(~np.isnan(raw_output))
 
+    def test_freeze_class(self, cnn_class):
+        """Test class network freezing."""
+        cnn_class.freeze(apply_inputs=False)
+        for params in cnn_class.network.parameters():
+            assert params.requires_grad is False
+        for params in cnn_class.network_tail.parameters():
+            assert params.requires_grad is False
+
+    def test_unfreeze_class(self, cnn_class):
+        """Test class network unfreezing."""
+        cnn_class.freeze(apply_inputs=False)
+        cnn_class.unfreeze(apply_inputs=False)
+        for params in cnn_class.network.parameters():
+            assert params.requires_grad is True
+        for params in cnn_class.network_tail.parameters():
+            assert params.requires_grad is True
+
+    def test_freeze_noclass(self, cnn_noclass):
+        """Test intermediate network freezing."""
+        cnn_noclass.freeze(apply_inputs=False)
+        for params in cnn_noclass.network.parameters():
+            assert params.requires_grad is False
+
+    def test_unfreeze_noclass(self, cnn_noclass):
+        """Test intermediate network unfreezing."""
+        cnn_noclass.freeze(apply_inputs=False)
+        cnn_noclass.unfreeze(apply_inputs=False)
+        for params in cnn_noclass.network.parameters():
+            assert params.requires_grad is True

--- a/vulcanai2/tests/models/test_dnn.py
+++ b/vulcanai2/tests/models/test_dnn.py
@@ -1,12 +1,17 @@
+"""Test all DenseNet capabilities."""
 import pytest
 import numpy as np
 import torch
 from vulcanai2.models.dnn import DenseNet
 from torch.utils.data import TensorDataset, DataLoader
 
+
 class TestDenseNet:
+    """Define DenseNet test class."""
+
     @pytest.fixture
     def dnn_noclass(self):
+        """Create DenseNet with no prediction layer."""
         return DenseNet(
             name='Test_DenseNet_class',
             dimensions=(200),
@@ -15,9 +20,10 @@ class TestDenseNet:
                 'dropout': [0.3, 0.5],
             }
         )
-    
+
     @pytest.fixture
     def dnn_class(self):
+        """Create DenseNet with prediction layer."""
         return DenseNet(
             name='Test_DenseNet_class',
             dimensions=(200),
@@ -36,7 +42,7 @@ class TestDenseNet:
             data_loader=test_dataloader,
             convert_to_class=False)
         assert np.any(~np.isnan(output))
-    
+
     def test_forward_class_not_nan(self, dnn_class):
         """Confirm out is non nan."""
         test_input = torch.ones([5, dnn_class.in_dim])
@@ -49,3 +55,32 @@ class TestDenseNet:
         assert np.any(~np.isnan(raw_output))
         assert np.any(~np.isnan(class_output))
 
+    def test_freeze_class(self, dnn_class):
+        """Test class network freezing."""
+        dnn_class.freeze(apply_inputs=False)
+        for params in dnn_class.network.parameters():
+            assert params.requires_grad is False
+        for params in dnn_class.network_tail.parameters():
+            assert params.requires_grad is False
+
+    def test_unfreeze_class(self, dnn_class):
+        """Test class network unfreezing."""
+        dnn_class.freeze(apply_inputs=False)
+        dnn_class.unfreeze(apply_inputs=False)
+        for params in dnn_class.network.parameters():
+            assert params.requires_grad is True
+        for params in dnn_class.network_tail.parameters():
+            assert params.requires_grad is True
+
+    def test_freeze_noclass(self, dnn_noclass):
+        """Test intermediate network freezing."""
+        dnn_noclass.freeze(apply_inputs=False)
+        for params in dnn_noclass.network.parameters():
+            assert params.requires_grad is False
+
+    def test_unfreeze_noclass(self, dnn_noclass):
+        """Test intermediate network unfreezing."""
+        dnn_noclass.freeze(apply_inputs=False)
+        dnn_noclass.unfreeze(apply_inputs=False)
+        for params in dnn_noclass.network.parameters():
+            assert params.requires_grad is True


### PR DESCRIPTION
I apologize for the overlap with the freeze weights PR (not exactly sure why it did that but anyway). I just moved the get_notable_indices to the utils for plotters. you can now have it like we did before with `from vulcanai2.models import DenseNet` instead of `from vulcanai2.models.dnn import DenseNet`