### PR TITLE
Weight bias init update

### DIFF
--- a/examples/fashion_conv_dense_test.py
+++ b/examples/fashion_conv_dense_test.py
@@ -137,7 +137,7 @@ multi_input_conv_3D_config = {
 }
 dense_config = {
     'dense_units': [100, 50],
-    'initializer': None,
+    'weight_init': None,
     'bias_init': None,
     'norm': None,
     'dropout': 0.5,  # Single value or List

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -66,13 +66,26 @@ class BaseUnit(nn.Sequential):
         if self.bias_init:
             self.bias_init(self._kernel.bias)
 
+
 def selu_weight_init_(tensor, mean=0):
+    """
+    Function assigned to variable that will be called within _init_weights function to assign weights for selu.
+    :param tensor: Weight tensor to be adjusted
+    :param mean: Mean value for the normal distribution
+    :return weight tensor with normal distribution
+    """
     with torch.no_grad():
         fan_in, _ = nn.init._calculate_fan_in_and_fan_out(tensor)
         std = math.sqrt(1. / fan_in)
         return nn.init.normal_(tensor.data, mean, std)
 
-def selu_bias_init_(tensor, const = 0.0):
+def selu_bias_init_(tensor, const=0.0):
+    """
+    Function assigned to variable that will be called within _init_bias function to assign bias for selu.
+    :param tensor:
+    :param const:
+    :return:
+    """
     with torch.no_grad():
         return nn.init.constant_(tensor.data, const)
 

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -63,7 +63,7 @@ class BaseUnit(nn.Sequential):
         if self.bias_init is None, then pytorch default bias
         will be assigned to the kernel
         """
-        if self.bias_init:
+        if self.bias_init is not None:
             nn.init.constant_(self._kernel.bias, self.bias_init)
 
 def selu_init_(tensor, mean=0):
@@ -162,6 +162,7 @@ class DenseUnit(BaseUnit):
             else:
                 self.add_module(
                     '_dropout', nn.Dropout(self.dropout))
+
         self._init_weights()
         self._init_bias()
 
@@ -262,6 +263,7 @@ class ConvUnit(BaseUnit):
                     '_dropout', self.dropout_layer(self.dropout))
         self._init_weights()
         self._init_bias()
+
     def _init_layers(self):
         if self.conv_dim == 1:
             self.conv_layer = nn.Conv1d

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 import logging
-import math
+from . import utils as utils
 logger = logging.getLogger(__name__)
 
 
@@ -67,45 +67,7 @@ class BaseUnit(nn.Sequential):
             self.bias_init(self._kernel.bias)
 
 
-def selu_weight_init_(tensor, mean=0.0):
-    """
-    Function assigned to variable that will be called within _init_weights function to assign weights for selu.
 
-    Parameters
-    ----------
-    tensor :  torch.tensor
-        Weight tensor to be adjusted
-    mean : float
-        Mean value for the normal distribution
-
-    Returns
-    -------
-    torch.tensor
-        weight tensor with normal distribution
-    """
-    with torch.no_grad():
-        fan_in, _ = nn.init._calculate_fan_in_and_fan_out(tensor)
-        std = math.sqrt(1. / fan_in)
-        return nn.init.normal_(tensor, mean, std)
-
-def selu_bias_init_(tensor, const=0.0):
-    """
-    Function assigned to variable that will be called within _init_bias function to assign bias for selu.
-
-    Parameters
-    ----------
-    tensor : torch.tensor
-        Bias tensor to be adjusted
-    const : float
-        Constant value to be assigned to tensor.
-
-    Returns
-    -------
-    torch.tensor
-        bias tensor with constant values.
-    """
-    with torch.no_grad():
-        return nn.init.constant_(tensor, const)
 
 class FlattenUnit(BaseUnit):
     """
@@ -186,8 +148,8 @@ class DenseUnit(BaseUnit):
         if activation is not None:
             self.add_module('_activation', activation)
             if isinstance(activation, nn.SELU):
-                self.weight_init = selu_weight_init_
-                self.bias_init = selu_bias_init_
+                self.weight_init = utils.selu_weight_init_
+                self.bias_init = utils.selu_bias_init_
 
         # Dropout
         if self.dropout is not None:
@@ -279,8 +241,8 @@ class ConvUnit(BaseUnit):
         if activation is not None:
             self.add_module('_activation', activation)
             if isinstance(activation, nn.SELU):
-                self.weight_init = selu_weight_init_
-                self.bias_init = selu_bias_init_
+                self.weight_init = utils.selu_weight_init_
+                self.bias_init = utils.selu_bias_init_
         # Pool
         if pool_size is not None:
             self.add_module(

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -67,12 +67,21 @@ class BaseUnit(nn.Sequential):
             self.bias_init(self._kernel.bias)
 
 
-def selu_weight_init_(tensor, mean=0):
+def selu_weight_init_(tensor, mean=0.0):
     """
     Function assigned to variable that will be called within _init_weights function to assign weights for selu.
-    :param tensor: Weight tensor to be adjusted
-    :param mean: Mean value for the normal distribution
-    :return weight tensor with normal distribution
+
+    Parameters
+    ----------
+    tensor :  torch.tensor
+        Weight tensor to be adjusted
+    mean : float
+        Mean value for the normal distribution
+
+    Returns
+    -------
+    torch.tensor
+        weight tensor with normal distribution
     """
     with torch.no_grad():
         fan_in, _ = nn.init._calculate_fan_in_and_fan_out(tensor)
@@ -82,9 +91,18 @@ def selu_weight_init_(tensor, mean=0):
 def selu_bias_init_(tensor, const=0.0):
     """
     Function assigned to variable that will be called within _init_bias function to assign bias for selu.
-    :param tensor: Bias tensor to be adjusted
-    :param const: Constant value to be assigned to tensor.
-    :return bias tensor with constant values.
+
+    Parameters
+    ----------
+    tensor:
+        Bias tensor to be adjusted
+    const:
+        Constant value to be assigned to tensor.
+
+    Returns
+    -------
+    torch.tensor
+        bias tensor with constant values.
     """
     with torch.no_grad():
         return nn.init.constant_(tensor, const)

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -132,7 +132,6 @@ class DenseUnit(BaseUnit):
                                         norm, dropout)
         self.in_features = in_features
         self.out_features = out_features
-        self.activation = activation
         # Main layer
         self._kernel = nn.Linear(
                             in_features=self.in_features,

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -33,7 +33,7 @@ class BaseUnit(nn.Sequential):
         """Initialize a base unit."""
         super(BaseUnit, self).__init__()
 
-        self.initializer = initializer
+        self.weight_init = initializer
         self.bias_init = bias_init
         self.norm = norm
         self.dropout = dropout
@@ -53,8 +53,8 @@ class BaseUnit(nn.Sequential):
         if self.initializer is None, then pytorch default weight
         will be assigned to the kernel
         """
-        if self.initializer:
-            self.initializer(self._kernel.weight)
+        if self.weight_init:
+            self.weight_init(self._kernel.weight)
 
     def _init_bias(self):
         """
@@ -156,7 +156,7 @@ class DenseUnit(BaseUnit):
         if activation is not None:
             self.add_module('_activation', activation)
             if isinstance(activation, nn.SELU):
-                self.initializer = selu_weight_init_
+                self.weight_init = selu_weight_init_
                 self.bias_init = selu_bias_init_
 
         # Dropout
@@ -249,9 +249,8 @@ class ConvUnit(BaseUnit):
         if activation is not None:
             self.add_module('_activation', activation)
             if isinstance(activation, nn.SELU):
-                self.initializer = selu_weight_init_
-                self.initializer = selu_bias_init_
-
+                self.weight_init = selu_weight_init_
+                self.bias_init = selu_bias_init_
         # Pool
         if pool_size is not None:
             self.add_module(

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -82,9 +82,9 @@ def selu_weight_init_(tensor, mean=0):
 def selu_bias_init_(tensor, const=0.0):
     """
     Function assigned to variable that will be called within _init_bias function to assign bias for selu.
-    :param tensor:
-    :param const:
-    :return:
+    :param tensor: Bias tensor to be adjusted
+    :param const: Constant value to be assigned to tensor.
+    :return bias tensor with constant values.
     """
     with torch.no_grad():
         return nn.init.constant_(tensor, const)

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -94,9 +94,9 @@ def selu_bias_init_(tensor, const=0.0):
 
     Parameters
     ----------
-    tensor:
+    tensor : torch.tensor
         Bias tensor to be adjusted
-    const:
+    const : float
         Constant value to be assigned to tensor.
 
     Returns

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 import logging
-from . import utils as utils
+from .utils import selu_bias_init_, selu_weight_init_
 logger = logging.getLogger(__name__)
 
 
@@ -148,8 +148,8 @@ class DenseUnit(BaseUnit):
         if activation is not None:
             self.add_module('_activation', activation)
             if isinstance(activation, nn.SELU):
-                self.weight_init = utils.selu_weight_init_
-                self.bias_init = utils.selu_bias_init_
+                self.weight_init = selu_weight_init_
+                self.bias_init = selu_bias_init_
 
         # Dropout
         if self.dropout is not None:
@@ -241,8 +241,8 @@ class ConvUnit(BaseUnit):
         if activation is not None:
             self.add_module('_activation', activation)
             if isinstance(activation, nn.SELU):
-                self.weight_init = utils.selu_weight_init_
-                self.bias_init = utils.selu_bias_init_
+                self.weight_init = selu_weight_init_
+                self.bias_init = selu_bias_init_
         # Pool
         if pool_size is not None:
             self.add_module(

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -119,7 +119,7 @@ class DenseUnit(BaseUnit):
         The incoming feature size of a sample.
     out_features : int
         The number of hidden Linear units for this layer.
-    init : torch.nn.init
+    weight_init : torch.nn.init
         Torch initialization function.
     bias_init : int or float
         A constant int or float to initialize biases with.

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -12,8 +12,8 @@ class BaseUnit(nn.Sequential):
 
     Parameters
     ----------
-    initializer : torch.nn.init
-        Torch initialization function.
+    weight_init : torch.nn.init
+        Torch initialization function for weights.
     bias_init : int or float
         A constant int or float to initialize biases with.
     norm : str
@@ -28,12 +28,12 @@ class BaseUnit(nn.Sequential):
 
     """
 
-    def __init__(self, initializer=None, bias_init=None,
+    def __init__(self, weight_init=None, bias_init=None,
                  norm=None, dropout=None):
         """Initialize a base unit."""
         super(BaseUnit, self).__init__()
 
-        self.weight_init = initializer
+        self.weight_init = weight_init
         self.bias_init = bias_init
         self.norm = norm
         self.dropout = dropout
@@ -77,7 +77,7 @@ def selu_weight_init_(tensor, mean=0):
     with torch.no_grad():
         fan_in, _ = nn.init._calculate_fan_in_and_fan_out(tensor)
         std = math.sqrt(1. / fan_in)
-        return nn.init.normal_(tensor.data, mean, std)
+        return nn.init.normal_(tensor, mean, std)
 
 def selu_bias_init_(tensor, const=0.0):
     """
@@ -87,7 +87,7 @@ def selu_bias_init_(tensor, const=0.0):
     :return:
     """
     with torch.no_grad():
-        return nn.init.constant_(tensor.data, const)
+        return nn.init.constant_(tensor, const)
 
 class FlattenUnit(BaseUnit):
     """
@@ -119,7 +119,7 @@ class DenseUnit(BaseUnit):
         The incoming feature size of a sample.
     out_features : int
         The number of hidden Linear units for this layer.
-    initializer : torch.nn.init
+    init : torch.nn.init
         Torch initialization function.
     bias_init : int or float
         A constant int or float to initialize biases with.
@@ -138,10 +138,10 @@ class DenseUnit(BaseUnit):
     """
 
     def __init__(self, in_features, out_features,
-                 initializer=None, bias_init=None,
+                 weight_init=None, bias_init=None,
                  norm=None, activation=None, dropout=None):
         """Initialize a single DenseUnit (i.e. a dense layer)."""
-        super(DenseUnit, self).__init__(initializer, bias_init,
+        super(DenseUnit, self).__init__(weight_init, bias_init,
                                         norm, dropout)
         self.in_features = in_features
         self.out_features = out_features
@@ -197,7 +197,7 @@ class ConvUnit(BaseUnit):
         The number of convolution kernels for this layer.
     kernel_size : int or tuple
         The size of the 1, 2, or 3 dimensional convolution kernel.
-    initializer : torch.nn.init
+    weight_init : torch.nn.init
         Torch initialization function.
     bias_init : int or float
         A constant int or float to initialize biases with.
@@ -222,11 +222,11 @@ class ConvUnit(BaseUnit):
     """
 
     def __init__(self, conv_dim, in_channels, out_channels, kernel_size,
-                 initializer=None, bias_init=None,
+                 weight_init=None, bias_init=None,
                  stride=1, padding=0, norm=None,
                  activation=None, pool_size=None, dropout=None):
         """Initialize a single ConvUnit (i.e. a conv layer)."""
-        super(ConvUnit, self).__init__(initializer, bias_init,
+        super(ConvUnit, self).__init__(weight_init, bias_init,
                                        norm, dropout)
         self.conv_dim = conv_dim
         self._init_layers()

--- a/vulcanai2/models/layers.py
+++ b/vulcanai2/models/layers.py
@@ -50,8 +50,8 @@ class BaseUnit(nn.Sequential):
         """
         Initialize the weights.
 
-        if self.initializer is None, then pytorch default weight
-        will be assigned to the kernel
+        If self.weight_init is None, then pytorch default weight
+        will be assigned to the kernel.
         """
         if self.weight_init:
             self.weight_init(self._kernel.weight)
@@ -60,13 +60,11 @@ class BaseUnit(nn.Sequential):
         """
         Initialize the bias.
 
-        if self.bias_init is None, then pytorch default bias
-        will be assigned to the kernel
+        If self.bias_init is None, then pytorch default bias
+        will be assigned to the kernel.
         """
         if self.bias_init:
             self.bias_init(self._kernel.bias)
-
-
 
 
 class FlattenUnit(BaseUnit):
@@ -161,6 +159,7 @@ class DenseUnit(BaseUnit):
                     '_dropout', nn.Dropout(self.dropout))
         self._init_weights()
         self._init_bias()
+
 
 # TODO: Automatically calculate padding to be the same as input shape.
 class ConvUnit(BaseUnit):

--- a/vulcanai2/models/utils.py
+++ b/vulcanai2/models/utils.py
@@ -1,10 +1,12 @@
 """Define utilities for all networks."""
 from math import ceil, floor
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 
 import numpy as np
+import math
 from sklearn.metrics import confusion_matrix
 from sklearn.preprocessing import LabelBinarizer
 from collections import OrderedDict as odict
@@ -210,3 +212,43 @@ def print_model_structure(network, input_size=None):
         if isinstance(v, odict):
             for k2, v2 in v.items():
                 print('\t {}: {}'.format(k2, v2))
+
+def selu_weight_init_(tensor, mean=0.0):
+    """
+    Function assigned to variable that will be called within _init_weights function to assign weights for selu.
+
+    Parameters
+    ----------
+    tensor :  torch.tensor
+        Weight tensor to be adjusted
+    mean : float
+        Mean value for the normal distribution
+
+    Returns
+    -------
+    torch.tensor
+        weight tensor with normal distribution
+    """
+    with torch.no_grad():
+        fan_in, _ = nn.init._calculate_fan_in_and_fan_out(tensor)
+        std = math.sqrt(1. / fan_in)
+        return nn.init.normal_(tensor, mean, std)
+
+def selu_bias_init_(tensor, const=0.0):
+    """
+    Function assigned to variable that will be called within _init_bias function to assign bias for selu.
+
+    Parameters
+    ----------
+    tensor : torch.tensor
+        Bias tensor to be adjusted
+    const : float
+        Constant value to be assigned to tensor.
+
+    Returns
+    -------
+    torch.tensor
+        bias tensor with constant values.
+    """
+    with torch.no_grad():
+        return nn.init.constant_(tensor, const)

--- a/vulcanai2/models/utils.py
+++ b/vulcanai2/models/utils.py
@@ -180,10 +180,7 @@ def network_summary(network, input_size=None):
 
 
 def print_model_structure(network, input_size=None):
-    """
-    Print the entire model structure.
-    
-    """
+    """Print the entire model structure."""
     shapes = network_summary(network)
     for k, v in shapes.items():
         print('{}:'.format(k))
@@ -194,7 +191,10 @@ def print_model_structure(network, input_size=None):
 
 def selu_weight_init_(tensor, mean=0.0):
     """
-    Function assigned to variable that will be called within _init_weights function to assign weights for selu.
+    SELU layer weight initialization function.
+
+    Function assigned to variable that will be called within
+    _init_weights function to assign weights for selu.
 
     Parameters
     ----------
@@ -207,6 +207,7 @@ def selu_weight_init_(tensor, mean=0.0):
     -------
     torch.tensor
         weight tensor with normal distribution
+
     """
     with torch.no_grad():
         fan_in, _ = nn.init._calculate_fan_in_and_fan_out(tensor)
@@ -216,7 +217,10 @@ def selu_weight_init_(tensor, mean=0.0):
 
 def selu_bias_init_(tensor, const=0.0):
     """
-    Function assigned to variable that will be called within _init_bias function to assign bias for selu.
+    SELU layer bias initialization function.
+
+    Function assigned to variable that will be called within
+    _init_bias function to assign bias for selu.
 
     Parameters
     ----------
@@ -229,6 +233,7 @@ def selu_bias_init_(tensor, const=0.0):
     -------
     torch.tensor
         bias tensor with constant values.
+
     """
     with torch.no_grad():
         return nn.init.constant_(tensor, const)
@@ -236,20 +241,19 @@ def selu_bias_init_(tensor, const=0.0):
 
 def set_tensor_device(data, device=None):
     """
-    Helper function to convert list of data to
-    relevant device
+    Convert list of data tensors to specified device.
 
     Parameters
     ----------
     data : torch.tensor or list
-        data to be converted to the relevant device.
+        data to be converted to the specified device.
     device : str or torch.device
         the desired device
 
     Returns
     -------
     data : torch.tensor or list
-        data converted to the relevant device
+        data converted to the specified device
 
     """
     if not isinstance(data, (list, tuple)):
@@ -262,13 +266,12 @@ def set_tensor_device(data, device=None):
 
 def master_device_setter(network, device=None):
     """
-    Helper function to convert the network and its 
-    input_networks to the relevant device.
+    Convert network and input_networks to specified device.
 
     Parameters
     ----------
     network : BaseNetwork
-        network to be converted to the relevant device.
+        network to be converted to the specified device.
     device : str or torch.device
         the desired device
 

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -1,5 +1,5 @@
+"""The script to test all layers and SELU activation properties hold."""
 import pytest
-import numpy as np
 import math
 import copy
 from functools import reduce
@@ -16,7 +16,7 @@ class TestBaseUnit:
 
     @pytest.fixture
     def baseunit(self):
-        """Base unit fixture."""
+        """Make Base unit fixture."""
         return BaseUnit()
 
 
@@ -96,7 +96,8 @@ class TestSeluInit:
     def test_conv_selu_weight_change(self, conv_unit):
         """Confirm SELU weight init properties hold for conv net."""
         starting_weight = copy.deepcopy(conv_unit._kernel.weight)
-        fan_in = conv_unit._kernel.in_channels * reduce(lambda kern1, kern2: kern1*kern2, conv_unit._kernel.kernel_size)
+        fan_in = conv_unit._kernel.in_channels * \
+            reduce(lambda k1, k2: k1 * k2, conv_unit._kernel.kernel_size)
         std = round(math.sqrt(1. / fan_in), 1)
         conv_unit.weight_init = selu_weight_init_
         conv_unit._init_weights()
@@ -188,7 +189,8 @@ class TestSeluInitTrain:
 
     def test_selu_trained_conv(self, cnn_class):
         """Confirm SELU weight and bias properties hold for a conv net."""
-        fan_in = cnn_class.network.conv_0.in_channels * reduce(lambda kern1, kern2: kern1*kern2, cnn_class.network.conv_0.kernel_size)
+        fan_in = cnn_class.network[0].in_channels * \
+            reduce(lambda k1, k2: k1 * k2, cnn_class.network[0].kernel_size)
         std = round(math.sqrt(1. / fan_in), 1)
         test_input = torch.ones([10, *cnn_class.in_dim]).float()
         test_target = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import math
 import copy
+from functools import reduce
 import torch
 from vulcanai2.models.layers import BaseUnit, ConvUnit, DenseUnit
 from vulcanai2.models.utils import selu_weight_init_, selu_bias_init_
@@ -95,7 +96,7 @@ class TestSeluInit:
     def test_conv_selu_weight_change(self, conv_unit):
         """Confirm SELU weight init properties hold for conv net."""
         starting_weight = copy.deepcopy(conv_unit._kernel.weight)
-        fan_in = conv_unit._kernel.in_channels * conv_unit._kernel.kernel_size[0] * conv_unit._kernel.kernel_size[1]
+        fan_in = conv_unit._kernel.in_channels * reduce(lambda kern1, kern2: kern1*kern2, conv_unit._kernel.kernel_size)
         std = round(math.sqrt(1. / fan_in), 1)
         conv_unit.weight_init = selu_weight_init_
         conv_unit._init_weights()
@@ -187,7 +188,7 @@ class TestSeluInitTrain:
 
     def test_selu_trained_conv(self, cnn_class):
         """Confirm SELU weight and bias properties hold for a conv net."""
-        fan_in = cnn_class.network.conv_0.in_channels * cnn_class.network.conv_0.kernel_size[0] * cnn_class.network.conv_0.kernel_size[1]
+        fan_in = cnn_class.network.conv_0.in_channels * reduce(lambda kern1, kern2: kern1*kern2, cnn_class.network.conv_0.kernel_size)
         std = round(math.sqrt(1. / fan_in), 1)
         test_input = torch.ones([10, *cnn_class.in_dim]).float()
         test_target = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -9,36 +9,47 @@ from vulcanai2.models.dnn import DenseNet
 from vulcanai2.models.cnn import ConvNet
 from torch.utils.data import TensorDataset, DataLoader
 
+
 class TestBaseUnit:
+    """To test BaseUnit layer."""
+
     @pytest.fixture
-    def baseunit(self): 
+    def baseunit(self):
+        """Base unit fixture."""
         return BaseUnit()
 
+
 class TestDenseUnit:
+    """To test DenseUnit layer."""
+
     @pytest.fixture
     def dense_unit(self):
+        """Dense unit fixture."""
         return DenseUnit(
             in_features=10,
             out_features=10
         )
-    
+
     def test_forward(self, dense_unit):
         """Confirm size is expected after forward."""
         test_input = torch.ones([1, dense_unit.in_features])
         output = dense_unit.forward(test_input)
         assert output.size() == torch.ones([1, dense_unit.out_features]).size()
-    
+
 
 class TestConvUnit:
+    """To test ConvUnit layers."""
+
     @pytest.fixture
     def conv_unit(self):
+        """Create ConvUnit fixture."""
         return ConvUnit(
             conv_dim=2,
             in_channels=10,
             out_channels=10,
-            kernel_size=(5,5)
+            kernel_size=(5, 5)
         )
-    
+
     def test_forward(self, conv_unit):
         """Confirm size is expected after forward."""
         test_input = torch.ones([1, conv_unit.in_channels, 28, 28])
@@ -46,23 +57,30 @@ class TestConvUnit:
         # No padding with 2 5x5 kernels leads from 28x28 -> 24x24
         assert output.size() == torch.ones([1, conv_unit.out_channels, 24, 24]).size()
 
+
 class TestSeluInit:
+    """To test selu initialized layer properties."""
+
     @pytest.fixture
     def dense_unit(self):
-        return DenseUnit(in_features=10,
-                         out_features=10
+        """Create a dense unit fixture."""
+        return DenseUnit(
+            in_features=10,
+            out_features=10
         )
 
     @pytest.fixture
     def conv_unit(self):
+        """Create a conv unit fixture."""
         return ConvUnit(
             conv_dim=2,
             in_channels=10,
             out_channels=10,
-            kernel_size=(5,5)
+            kernel_size=(5, 5)
         )
 
     def test_dense_selu_weight_change(self, dense_unit):
+        """Confirm SELU weight init properties hold for dense net."""
         starting_weight = copy.deepcopy(dense_unit._kernel.weight)
         std = round(math.sqrt(1. / 10), 1)
 
@@ -74,6 +92,7 @@ class TestSeluInit:
         assert (int(new_weight.mean().item()) == 0.0)
 
     def test_conv_selu_weight_change(self, conv_unit):
+        """Confirm SELU weight init properties hold for conv net."""
         starting_weight = copy.deepcopy(conv_unit._kernel.weight)
         std = round(math.sqrt(1. / 250), 1)
         conv_unit.weight_init = selu_weight_init_
@@ -84,6 +103,7 @@ class TestSeluInit:
         assert (int(new_weight.mean().item()) == 0)
 
     def test_dense_selu_bias_change(self, dense_unit):
+        """Confirm SELU bias init properties hold for dense net."""
         starting_bias = copy.deepcopy(dense_unit._kernel.bias)
 
         dense_unit.bias_init = selu_bias_init_
@@ -94,6 +114,7 @@ class TestSeluInit:
         assert (int(new_bias.mean().item()) == 0)
 
     def test_conv_selu_bias_change(self, conv_unit):
+        """Confirm SELU bias init properties hold for conv net."""
         starting_bias = copy.deepcopy(conv_unit._kernel.bias)
 
         conv_unit.bias_init = selu_bias_init_
@@ -103,7 +124,10 @@ class TestSeluInit:
         assert (round(new_bias.std().item(), 1) == 0.0)
         assert (int(new_bias.mean().item()) == 0)
 
+
 class TestSeluInitTrain:
+    """To test selu initialization properties hold during training."""
+
     @pytest.fixture
     def dnn_class(self):
         """Create DenseNet with no prediction layer."""
@@ -111,7 +135,7 @@ class TestSeluInitTrain:
             name='Test_DenseNet_class',
             in_dim=(200),
             activation=torch.nn.SELU(),
-            num_classes=3,
+            num_classes=10,
             config={
                 'dense_units': [100],
                 'dropout': [0.3],
@@ -142,13 +166,14 @@ class TestSeluInitTrain:
                         "padding": 2
                     }]
             },
-            num_classes=6
+            num_classes=10
         )
 
     def test_selu_trained_dense(self, dnn_class):
+        """Confirm SELU weight and bias properties hold for a dense net."""
         std = round(math.sqrt(1. / 200), 1)
-        test_input = torch.ones([5, *dnn_class.in_dim]).float()
-        test_target = torch.LongTensor([0, 2, 1, 2, 1])
+        test_input = torch.ones([10, *dnn_class.in_dim]).float()
+        test_target = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         test_dataloader = DataLoader(TensorDataset(test_input, test_target))
         dnn_class.fit(test_dataloader, test_dataloader, 5)
         trained = copy.deepcopy(dnn_class.network.dense_0._kernel)
@@ -158,9 +183,10 @@ class TestSeluInitTrain:
         assert (int(trained.bias.mean().item()) == 0.0)
 
     def test_selu_trained_conv(self, cnn_class):
+        """Confirm SELU weight and bias properties hold for a conv net."""
         std = round(math.sqrt(1. / 25), 1)
-        test_input = torch.ones([13, *cnn_class.in_dim]).float()
-        test_target = torch.LongTensor([0, 2, 1, 3, 4, 1, 2, 2, 3, 0, 4, 5, 0])
+        test_input = torch.ones([10, *cnn_class.in_dim]).float()
+        test_target = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         test_dataloader = DataLoader(TensorDataset(test_input, test_target))
         cnn_class.fit(test_dataloader, test_dataloader, 5)
         trained = copy.copy(cnn_class.network.conv_0._kernel)

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -1,7 +1,10 @@
 import pytest
 import numpy as np
+import math
+import copy
 import torch
 from vulcanai2.models.layers import *
+from vulcanai2.models.utils import selu_weight_init_, selu_bias_init_
 
 class TestBaseUnit:
     @pytest.fixture
@@ -40,3 +43,49 @@ class TestConvUnit:
         # No padding with 2 5x5 kernels leads from 28x28 -> 24x24
         assert output.size() == torch.ones([1, conv_unit.out_channels, 24, 24]).size()
 
+class TestSeluWeightInit:
+    @pytest.fixture
+    def dense_unit(self):
+        return DenseUnit(in_features=10,
+                         out_features=10
+        )
+
+    def conv_unit(self):
+        return ConvUnit(
+            conv_dim=2,
+            in_channels=10,
+            out_channels=10,
+            kernel_size=(5,5)
+        )
+
+    def test_dense_selu_weight_change(self, dense_unit):
+        starting_weight = copy.deepcopy(dense_unit._kernel.weight)
+        std = math.sqrt(1. / 10)
+        #Produce upper and lower by finding values that are 3 standard deviations from mean
+        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
+        upper = 3 * std
+        lower = 3 * (-(math.sqrt(1. /10)))
+
+
+        dense_unit.weight_init = selu_weight_init_
+        dense_unit.weight_init(dense_unit._kernel.weight)
+        new_weight = copy.deepcopy(dense_unit._kernel.weight)
+        assert ((torch.equal(starting_weight, new_weight) is False) and
+               (new_weight.max().item() <= upper) and
+               (new_weight.min().item() >= lower))
+
+    def test_dense_selu_bias_change(self, dense_unit):
+        starting_bias = copy.deepcopy(dense_unit._kernel.bias)
+        std = math.sqrt(1. / 10)
+        #Produce upper and lower by finding values that are 3 standard deviations from mean
+        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
+        upper = 3 * std
+        lower = 3 * (-(math.sqrt(1. /10)))
+
+
+        dense_unit.bias_init = selu_bias_init_
+        dense_unit.bias_init(dense_unit._kernel.bias)
+        new_bias = copy.deepcopy(dense_unit._kernel.bias)
+        assert ((torch.equal(starting_bias, new_bias) is False) and
+               (new_bias.max().item() <= upper) and
+               (new_bias.min().item() >= lower))

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -3,7 +3,7 @@ import numpy as np
 import math
 import copy
 import torch
-from vulcanai2.models.layers import *
+from vulcanai2.models.layers import BaseUnit, ConvUnit, DenseUnit
 from vulcanai2.models.utils import selu_weight_init_, selu_bias_init_
 from vulcanai2.models.dnn import DenseNet
 from vulcanai2.models.cnn import ConvNet

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -50,6 +50,7 @@ class TestSeluWeightInit:
                          out_features=10
         )
 
+    @pytest.fixture
     def conv_unit(self):
         return ConvUnit(
             conv_dim=2,
@@ -64,12 +65,27 @@ class TestSeluWeightInit:
         #Produce upper and lower by finding values that are 3 standard deviations from mean
         # Statistically, ~99% of values in normal distribution are 3 std away from mean.
         upper = 3 * std
-        lower = 3 * (-(math.sqrt(1. /10)))
+        lower = 3 * (-(math.sqrt(1. / 10)))
 
 
         dense_unit.weight_init = selu_weight_init_
         dense_unit.weight_init(dense_unit._kernel.weight)
         new_weight = copy.deepcopy(dense_unit._kernel.weight)
+        assert ((torch.equal(starting_weight, new_weight) is False) and
+               (new_weight.max().item() <= upper) and
+               (new_weight.min().item() >= lower))
+
+    def test_conv_selu_weight_change(self, conv_unit):
+        starting_weight = copy.deepcopy(conv_unit._kernel.weight)
+        std = math.sqrt(1. / 10)
+        #Produce upper and lower by finding values that are 3 standard deviations from mean
+        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
+        upper = 3 * std
+        lower = 3 * (-(math.sqrt(1. / 10)))
+
+        conv_unit.weight_init = selu_weight_init_
+        conv_unit.weight_init(conv_unit._kernel.weight)
+        new_weight = copy.deepcopy(conv_unit._kernel.weight)
         assert ((torch.equal(starting_weight, new_weight) is False) and
                (new_weight.max().item() <= upper) and
                (new_weight.min().item() >= lower))
@@ -80,12 +96,28 @@ class TestSeluWeightInit:
         #Produce upper and lower by finding values that are 3 standard deviations from mean
         # Statistically, ~99% of values in normal distribution are 3 std away from mean.
         upper = 3 * std
-        lower = 3 * (-(math.sqrt(1. /10)))
+        lower = 3 * (-(math.sqrt(1. / 10)))
 
 
         dense_unit.bias_init = selu_bias_init_
         dense_unit.bias_init(dense_unit._kernel.bias)
         new_bias = copy.deepcopy(dense_unit._kernel.bias)
+        assert ((torch.equal(starting_bias, new_bias) is False) and
+               (new_bias.max().item() <= upper) and
+               (new_bias.min().item() >= lower))
+
+    def test_conv_selu_bias_change(self, conv_unit):
+        starting_bias = copy.deepcopy(conv_unit._kernel.bias)
+        std = math.sqrt(1. / 10)
+        #Produce upper and lower by finding values that are 3 standard deviations from mean
+        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
+        upper = 3 * std
+        lower = 3 * (-(math.sqrt(1. / 10)))
+
+
+        conv_unit.bias_init = selu_bias_init_
+        conv_unit.bias_init(conv_unit._kernel.bias)
+        new_bias = copy.deepcopy(conv_unit._kernel.bias)
         assert ((torch.equal(starting_bias, new_bias) is False) and
                (new_bias.max().item() <= upper) and
                (new_bias.min().item() >= lower))

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -85,10 +85,10 @@ class TestSeluInit:
         std = round(math.sqrt(1. / 10), 1)
 
         dense_unit.weight_init = selu_weight_init_
-        dense_unit.weight_init(dense_unit._kernel.weight)
+        dense_unit._init_weights()
         new_weight = copy.deepcopy(dense_unit._kernel.weight)
         assert (torch.equal(starting_weight, new_weight) is False)
-        assert (round(new_weight.std().item(), 1) == std)
+        assert pytest.approx(round(new_weight.std().item(), 1), 0.1) == std
         assert (int(new_weight.mean().item()) == 0.0)
 
     def test_conv_selu_weight_change(self, conv_unit):
@@ -96,10 +96,10 @@ class TestSeluInit:
         starting_weight = copy.deepcopy(conv_unit._kernel.weight)
         std = round(math.sqrt(1. / 250), 1)
         conv_unit.weight_init = selu_weight_init_
-        conv_unit.weight_init(conv_unit._kernel.weight)
+        conv_unit._init_weights()
         new_weight = copy.deepcopy(conv_unit._kernel.weight)
         assert (torch.equal(starting_weight, new_weight) is False)
-        assert (round(new_weight.std().item(), 1) == std)
+        assert pytest.approx(round(new_weight.std().item(), 1), 0.1) == std
         assert (int(new_weight.mean().item()) == 0)
 
     def test_dense_selu_bias_change(self, dense_unit):
@@ -107,7 +107,7 @@ class TestSeluInit:
         starting_bias = copy.deepcopy(dense_unit._kernel.bias)
 
         dense_unit.bias_init = selu_bias_init_
-        dense_unit.bias_init(dense_unit._kernel.bias)
+        dense_unit._init_bias()
         new_bias = copy.deepcopy(dense_unit._kernel.bias)
         assert (torch.equal(starting_bias, new_bias) is False)
         assert (round(new_bias.std().item(), 1) == 0.0)
@@ -118,7 +118,7 @@ class TestSeluInit:
         starting_bias = copy.deepcopy(conv_unit._kernel.bias)
 
         conv_unit.bias_init = selu_bias_init_
-        conv_unit.bias_init(conv_unit._kernel.bias)
+        conv_unit._init_bias()
         new_bias = copy.deepcopy(conv_unit._kernel.bias)
         assert (torch.equal(starting_bias, new_bias) is False)
         assert (round(new_bias.std().item(), 1) == 0.0)

--- a/vulcanai2/tests/models/test_layers.py
+++ b/vulcanai2/tests/models/test_layers.py
@@ -61,63 +61,42 @@ class TestSeluWeightInit:
 
     def test_dense_selu_weight_change(self, dense_unit):
         starting_weight = copy.deepcopy(dense_unit._kernel.weight)
-        std = math.sqrt(1. / 10)
-        #Produce upper and lower by finding values that are 3 standard deviations from mean
-        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
-        upper = 3 * std
-        lower = 3 * (-(math.sqrt(1. / 10)))
-
+        std = round(math.sqrt(1. / 10), 1)
 
         dense_unit.weight_init = selu_weight_init_
         dense_unit.weight_init(dense_unit._kernel.weight)
         new_weight = copy.deepcopy(dense_unit._kernel.weight)
-        assert ((torch.equal(starting_weight, new_weight) is False) and
-               (new_weight.max().item() <= upper) and
-               (new_weight.min().item() >= lower))
+        assert (torch.equal(starting_weight, new_weight) is False)
+        assert (round(new_weight.std().item(), 1) == std)
+        assert (round(new_weight.mean().item(), 0) == 0.0)
 
     def test_conv_selu_weight_change(self, conv_unit):
         starting_weight = copy.deepcopy(conv_unit._kernel.weight)
-        std = math.sqrt(1. / 10)
-        #Produce upper and lower by finding values that are 3 standard deviations from mean
-        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
-        upper = 3 * std
-        lower = 3 * (-(math.sqrt(1. / 10)))
+        std = round(math.sqrt(1. / 250), 1)
 
         conv_unit.weight_init = selu_weight_init_
         conv_unit.weight_init(conv_unit._kernel.weight)
         new_weight = copy.deepcopy(conv_unit._kernel.weight)
-        assert ((torch.equal(starting_weight, new_weight) is False) and
-               (new_weight.max().item() <= upper) and
-               (new_weight.min().item() >= lower))
+        assert (torch.equal(starting_weight, new_weight) is False)
+        assert (round(new_weight.std().item(), 1) == std)
+        assert (round(new_weight.mean().item(), 0) == 0.0)
 
     def test_dense_selu_bias_change(self, dense_unit):
         starting_bias = copy.deepcopy(dense_unit._kernel.bias)
-        std = math.sqrt(1. / 10)
-        #Produce upper and lower by finding values that are 3 standard deviations from mean
-        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
-        upper = 3 * std
-        lower = 3 * (-(math.sqrt(1. / 10)))
-
 
         dense_unit.bias_init = selu_bias_init_
         dense_unit.bias_init(dense_unit._kernel.bias)
         new_bias = copy.deepcopy(dense_unit._kernel.bias)
-        assert ((torch.equal(starting_bias, new_bias) is False) and
-               (new_bias.max().item() <= upper) and
-               (new_bias.min().item() >= lower))
+        assert (torch.equal(starting_bias, new_bias) is False)
+        assert (round(new_bias.std().item(), 1) == 0.0)
+        assert (round(new_bias.mean().item(), 0) == 0.0)
 
     def test_conv_selu_bias_change(self, conv_unit):
         starting_bias = copy.deepcopy(conv_unit._kernel.bias)
-        std = math.sqrt(1. / 10)
-        #Produce upper and lower by finding values that are 3 standard deviations from mean
-        # Statistically, ~99% of values in normal distribution are 3 std away from mean.
-        upper = 3 * std
-        lower = 3 * (-(math.sqrt(1. / 10)))
-
 
         conv_unit.bias_init = selu_bias_init_
         conv_unit.bias_init(conv_unit._kernel.bias)
         new_bias = copy.deepcopy(conv_unit._kernel.bias)
-        assert ((torch.equal(starting_bias, new_bias) is False) and
-               (new_bias.max().item() <= upper) and
-               (new_bias.min().item() >= lower))
+        assert (torch.equal(starting_bias, new_bias) is False)
+        assert (round(new_bias.std().item(), 1) == 0.0)
+        assert (round(new_bias.mean().item(), 0) == 0.0)


### PR DESCRIPTION
Fix #85 
Created `selu_init_` function to mimic pytorch's method for initializing with a normal distribution based on standard deviation of the number of input features. In `DenseUnit` and `ConvUnit` class when checking if activation is SELU set the initilizer to `selu_int_` function and set `bias_init` to 0.0. 